### PR TITLE
Add an example on how to run over all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The linter can be run from the command line. The basic usage is:
 fsh-lint --paths path/to/YourFile.fsh
 ```
 
+Or over all fsh files in the `input/fsh` directory:
+```bash
+find input/fsh -name "*.fsh" -exec fsh-lint --paths {} \;
+```
+
 Automatic fixes are available for some rules as well, which can be applied with
 the `--fix` flag:
 


### PR DESCRIPTION
Add an example on how to run over all files. `fsh-lint --paths input/fsh/*.fsh` didn't work, but this workaround did.